### PR TITLE
Use color picker to choose colors

### DIFF
--- a/NppExec/NppExec_DevCpp.dev
+++ b/NppExec/NppExec_DevCpp.dev
@@ -1,7 +1,7 @@
 [Project]
 FileName=NppExec_DevCpp.dev
 Name=NppExec
-UnitCount=84
+UnitCount=85
 Type=3
 Ver=2
 IsCpp=1
@@ -922,3 +922,12 @@ Priority=1000
 OverrideBuildCmd=0
 BuildCmd=
 
+[Unit85]
+FileName=src\PickColorBtn.cpp
+CompileCpp=1
+Folder=NppExec
+Compile=1
+Link=1
+Priority=1000
+OverrideBuildCmd=0
+BuildCmd=

--- a/NppExec/NppExec_VC2015.vcxproj
+++ b/NppExec/NppExec_VC2015.vcxproj
@@ -276,6 +276,7 @@
     <ClCompile Include="src\DlgInputBox.cpp" />
     <ClCompile Include="src\encodings\SysUniConv.cpp" />
     <ClCompile Include="src\fparser\fparser.cc" />
+    <ClCompile Include="src\PickColorBtn.cpp" />
     <ClCompile Include="src\NppExec.cpp" />
     <ClCompile Include="src\NppExecCommandExecutor.cpp" />
     <ClCompile Include="src\NppExecEngine.cpp" />

--- a/NppExec/NppExec_VC2017.vcxproj
+++ b/NppExec/NppExec_VC2017.vcxproj
@@ -277,6 +277,7 @@
     <ClCompile Include="src\DlgInputBox.cpp" />
     <ClCompile Include="src\encodings\SysUniConv.cpp" />
     <ClCompile Include="src\fparser\fparser.cc" />
+    <ClCompile Include="src\PickColorBtn.cpp" />
     <ClCompile Include="src\NppExec.cpp" />
     <ClCompile Include="src\NppExecCommandExecutor.cpp" />
     <ClCompile Include="src\NppExecEngine.cpp" />

--- a/NppExec/NppExec_VC2019.vcxproj
+++ b/NppExec/NppExec_VC2019.vcxproj
@@ -277,6 +277,7 @@
     <ClCompile Include="src\DlgInputBox.cpp" />
     <ClCompile Include="src\encodings\SysUniConv.cpp" />
     <ClCompile Include="src\fparser\fparser.cc" />
+    <ClCompile Include="src\PickColorBtn.cpp" />
     <ClCompile Include="src\NppExec.cpp" />
     <ClCompile Include="src\NppExecCommandExecutor.cpp" />
     <ClCompile Include="src\NppExecEngine.cpp" />

--- a/NppExec/src/CAnyWindow.h
+++ b/NppExec/src/CAnyWindow.h
@@ -32,6 +32,7 @@ public:
 
   CAnyWindow();
   ~CAnyWindow();
+  HWND    GetWindowHandle() { return m_hWnd; }
   BOOL    BringWindowToTop();
   BOOL    CenterWindow(HWND hParentWnd, BOOL bRepaint = FALSE);
   BOOL    EnableWindow(BOOL bEnable = TRUE);

--- a/NppExec/src/DlgAdvancedOptions.cpp
+++ b/NppExec/src/DlgAdvancedOptions.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DlgAdvancedOptions.h"
 #include "CAnyWindow.h"
+#include "PickColorBtn.h"
 #include "NppExec.h"
 #include "DlgDoExec.h"
 #include "DlgConsole.h"
@@ -34,15 +35,13 @@ extern COLORREF g_colorTextErr;
 extern COLORREF g_colorTextMsg;
 extern COLORREF g_colorBkgnd;
 
-typedef const c_base::byte_t * lpcbyte_t;
-
 CAdvOptDlg advOptDlg;
 
 INT_PTR CALLBACK AdvancedOptionsDlgProc(
   HWND   hDlg, 
   UINT   uMessage, 
   WPARAM wParam, 
-  LPARAM /*lParam*/)
+  LPARAM lParam)
 {
     if ( uMessage == WM_COMMAND )
     {
@@ -143,6 +142,11 @@ INT_PTR CALLBACK AdvancedOptionsDlgProc(
         }
     }
 
+    else if ( uMessage == WM_NOTIFY )
+    {
+        PickColorBtn_HandleTooltipsNotify(hDlg, wParam, lParam);
+    }
+
     else if ( uMessage == WM_SYSCOMMAND )
     {
         if ( wParam == SC_CLOSE )
@@ -158,7 +162,9 @@ INT_PTR CALLBACK AdvancedOptionsDlgProc(
         advOptDlg.OnInitDlg(hDlg);
     }
 
-    return 0;
+    // Note: This is greedy and must be the last handler
+    if (PickColorBtn::HandleMessageForDialog(hDlg, uMessage, wParam, lParam)) return true;
+    return false;
 }
 
 CAdvOptDlg::CAdvOptDlg() : CAnyWindow()
@@ -201,13 +207,9 @@ void CAdvOptDlg::OnInitDlg(HWND hDlg)
 
     m_edItemName.SendMsg(EM_LIMITTEXT, MAX_SCRIPTNAME/2, 0);
     m_edCommentDelim.SendMsg(EM_LIMITTEXT, 9, 0);
-    m_edTextColorNorm.SendMsg(EM_LIMITTEXT, 9, 0);
-    m_edTextColorErr.SendMsg(EM_LIMITTEXT, 9, 0);
-    m_edTextColorMsg.SendMsg(EM_LIMITTEXT, 9, 0);
-    m_edBkColor.SendMsg(EM_LIMITTEXT, 9, 0);
     
     // notepad++ macros submenu...
-    
+
     m_chMacrosSubmenu.SetCheck( Options.GetBool(OPTB_USERMENU_NPPMACROS) ? TRUE : FALSE );
     
     int     i;
@@ -330,33 +332,18 @@ void CAdvOptDlg::OnInitDlg(HWND hDlg)
     
     // fill edit-controls...
 
-    TCHAR szText[64];
-
     S = Options.GetStr(OPTS_COMMENTDELIMITER);
     m_edCommentDelim.SetWindowText(S.c_str());
-    
-    szText[0] = 0;
-    c_base::_tbuf2hexstr( (lpcbyte_t) &g_colorTextNorm, 3, szText, 64 - 1, _T(" ") );
-    m_edTextColorNorm.SetWindowText(szText);
-    
-    szText[0] = 0;
-    c_base::_tbuf2hexstr( (lpcbyte_t) &g_colorTextErr, 3, szText, 64 - 1, _T(" ") );
-    m_edTextColorErr.SetWindowText(szText);
-    
-    szText[0] = 0;
-    c_base::_tbuf2hexstr( (lpcbyte_t) &g_colorTextMsg, 3, szText, 64 - 1, _T(" ") );
-    m_edTextColorMsg.SetWindowText(szText);
-    
-    if ( g_colorBkgnd == COLOR_CON_BKGND )
-    {
-        m_edBkColor.SetWindowText( _T("0") );
-    }
-    else
-    {
-        szText[0] = 0;
-        c_base::_tbuf2hexstr( (lpcbyte_t) &g_colorBkgnd, 3, szText, 64 - 1, _T(" ") );
-        m_edBkColor.SetWindowText(szText);
-    }
+
+    COLORREF clr;
+    PickColorBtn_SetColor(m_edTextColorNorm.GetWindowHandle(), g_colorTextNorm);
+    PickColorBtn_SetColor(m_edTextColorErr.GetWindowHandle(), g_colorTextErr);
+    PickColorBtn_SetColor(m_edTextColorMsg.GetWindowHandle(), g_colorTextMsg);
+    clr = g_colorBkgnd;
+    if (clr == COLOR_CON_BKGND) clr |= (COLOR_CON_BKGND & 0xff000000);
+    PickColorBtn_SetColor(m_edBkColor.GetWindowHandle(), clr);
+
+    PickColorBtn_InitializeTooltips(hDlg, IDC_ED_OPT_TEXTCOLORNORM, IDC_ED_OPT_BKCOLOR);
 
     BOOL bUseEditorColors = Options.GetBool(OPTB_CONSOLE_USEEDITORCOLORS) ? TRUE : FALSE;
     m_chUseEditorColorsInConsole.SetCheck(bUseEditorColors);
@@ -391,96 +378,41 @@ void CAdvOptDlg::OnInitDlg(HWND hDlg)
     advOptDlg.CenterWindow(NppExec.m_nppData._nppHandle);
 }
 
+template<class OM, class W> static void SaveColorOption(
+  OM &Options, 
+  W &Wnd, 
+  UINT Optd, 
+  COLORREF &Var, 
+  COLORREF Default)
+{
+    c_base::byte_t bt[4];
+    bool invalid = false;
+    COLORREF clr = PickColorBtn_GetColor(Wnd.GetWindowHandle());
+    bt[0] = GetRValue(clr), bt[1] = GetGValue(clr), bt[2] = GetBValue(clr);
+    if (clr & 0xff000000)
+    {
+        clr = Default;
+        invalid = true;
+        bt[0] = 0;
+    }
+    Options.SetData(Optd, bt, invalid ? 1 : 3);
+    Var = clr;
+}
+
 BOOL CAdvOptDlg::OnBtOK()
 {
     CNppExec& NppExec = Runtime::GetNppExec();
     CStaticOptionsManager& Options = NppExec.GetOptions();
 
-    c_base::byte_t bt[4];
     TCHAR szText[MAX_SCRIPTNAME];
     int   i;
 
     // text/background colours...
 
-    bt[0] = 0;
-    szText[0] = 0;
-    m_edTextColorNorm.GetWindowText(szText, MAX_SCRIPTNAME - 1);
-    i = c_base::_thexstr2buf( szText, bt, 4 );
-    if ( i >= 3 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTNORM, bt, 3);
-        g_colorTextNorm = RGB( bt[0], bt[1], bt[2] );
-    }
-    else if ( i <= 1 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTNORM, bt, 1);
-        g_colorTextNorm = COLOR_CON_TEXTNORM;
-    }
-    else
-    {
-        ShowError( _T("Incorrect value of TextColorNormal") );
-        return FALSE;
-    }
-
-    bt[0] = 0;
-    szText[0] = 0;
-    m_edTextColorErr.GetWindowText(szText, MAX_SCRIPTNAME - 1);
-    i = c_base::_thexstr2buf( szText, bt, 4 );
-    if ( i >= 3 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTERR, bt, 3);
-        g_colorTextErr = RGB( bt[0], bt[1], bt[2] );
-    }
-    else if ( i <= 1 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTERR, bt, 1);
-        g_colorTextErr = COLOR_CON_TEXTERR;
-    }
-    else
-    {
-        ShowError( _T("Incorrect value of TextColorError") );
-        return FALSE;
-    }
-
-    bt[0] = 0;
-    szText[0] = 0;
-    m_edTextColorMsg.GetWindowText(szText, MAX_SCRIPTNAME - 1);
-    i = c_base::_thexstr2buf( szText, bt, 4 );
-    if ( i >= 3 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTMSG, bt, 3);
-        g_colorTextMsg = RGB( bt[0], bt[1], bt[2] );
-    }
-    else if ( i <= 1 )
-    {
-        Options.SetData(OPTD_COLOR_TEXTMSG, bt, 1);
-        g_colorTextMsg = COLOR_CON_TEXTMSG;
-    }
-    else
-    {
-        ShowError( _T("Incorrect value of TextColorMessage") );
-        return FALSE;
-    }
-
-    bt[0] = 0;
-    szText[0] = 0;
-    m_edBkColor.GetWindowText(szText, MAX_SCRIPTNAME - 1);
-    i = c_base::_thexstr2buf( szText, bt, 4 );
-    if ( i >= 3 )
-    {
-        Options.SetData(OPTD_COLOR_BKGND, bt, 3);
-        g_colorBkgnd = RGB( bt[0], bt[1], bt[2] );
-    }
-    else if ( i <= 1 )
-    {
-        Options.SetData(OPTD_COLOR_BKGND, bt, 1);
-        g_colorBkgnd = COLOR_CON_BKGND;
-    }
-    else
-    {
-        ShowError( _T("Incorrect value of BackgroundColor") );
-        return FALSE;
-    }
+    SaveColorOption(Options, m_edTextColorNorm, OPTD_COLOR_TEXTNORM, g_colorTextNorm, COLOR_CON_TEXTNORM);
+    SaveColorOption(Options, m_edTextColorErr, OPTD_COLOR_TEXTERR, g_colorTextErr, COLOR_CON_TEXTERR);
+    SaveColorOption(Options, m_edTextColorMsg, OPTD_COLOR_TEXTMSG, g_colorTextMsg, COLOR_CON_TEXTMSG);
+    SaveColorOption(Options, m_edBkColor, OPTD_COLOR_BKGND, g_colorBkgnd, COLOR_CON_BKGND);
 
     Options.SetBool( OPTB_CONSOLE_USEEDITORCOLORS, m_chUseEditorColorsInConsole.IsChecked() ? true : false );
     Options.SetBool( OPTB_EXECDLG_USEEDITORCOLORS, m_chUseEditorColorsInExecDlg.IsChecked() ? true : false );
@@ -892,19 +824,19 @@ void CAdvOptDlg::ShowWarning(LPCTSTR szMessage)
 
 void CAdvOptDlg::colorValuesInit()
 {
-    m_bufColorTextNorm.Assign( (lpcbyte_t) &g_colorTextNorm, sizeof(COLORREF) );
-    m_bufColorTextErr.Assign( (lpcbyte_t) &g_colorTextErr, sizeof(COLORREF) );
-    m_bufColorTextMsg.Assign( (lpcbyte_t) &g_colorTextMsg, sizeof(COLORREF) );
-    m_bufColorBkgnd.Assign( (lpcbyte_t) &g_colorBkgnd, sizeof(COLORREF) );
+    m_OrgColorTextNorm = g_colorTextNorm;
+    m_OrgColorTextErr = g_colorTextErr;
+    m_OrgColorTextMsg = g_colorTextMsg;
+    m_OrgColorBkgnd = g_colorBkgnd;
     m_bUseEditorColorsInConsole = Runtime::GetNppExec().GetOptions().GetBool(OPTB_CONSOLE_USEEDITORCOLORS);
 }
 
 BOOL CAdvOptDlg::colorValuesChanged()
 {
-    if ( m_bufColorTextNorm.Compare((lpcbyte_t) &g_colorTextNorm, sizeof(COLORREF)) != 0 ||
-         m_bufColorTextErr.Compare((lpcbyte_t) &g_colorTextErr, sizeof(COLORREF)) != 0 ||
-         m_bufColorTextMsg.Compare((lpcbyte_t) &g_colorTextMsg, sizeof(COLORREF)) != 0 ||
-         m_bufColorBkgnd.Compare((lpcbyte_t) &g_colorBkgnd, sizeof(COLORREF)) != 0 ||
+    if ( m_OrgColorTextNorm != g_colorTextNorm ||
+         m_OrgColorTextErr != g_colorTextErr ||
+         m_OrgColorTextMsg != g_colorTextMsg ||
+         m_OrgColorBkgnd != g_colorBkgnd ||
          m_bUseEditorColorsInConsole != Runtime::GetNppExec().GetOptions().GetBool(OPTB_CONSOLE_USEEDITORCOLORS) )
     {
         return TRUE;

--- a/NppExec/src/DlgAdvancedOptions.cpp
+++ b/NppExec/src/DlgAdvancedOptions.cpp
@@ -163,7 +163,7 @@ INT_PTR CALLBACK AdvancedOptionsDlgProc(
     }
 
     // Note: This is greedy and must be the last handler
-    if (PickColorBtn::HandleMessageForDialog(hDlg, uMessage, wParam, lParam)) return true;
+    if (PickColorBtn_HandleMessageForDialog(hDlg, uMessage, wParam, lParam)) return true;
     return false;
 }
 
@@ -378,12 +378,9 @@ void CAdvOptDlg::OnInitDlg(HWND hDlg)
     advOptDlg.CenterWindow(NppExec.m_nppData._nppHandle);
 }
 
-template<class OM, class W> static void SaveColorOption(
-  OM &Options, 
-  W &Wnd, 
-  UINT Optd, 
-  COLORREF &Var, 
-  COLORREF Default)
+static void SaveColorOption(
+  CStaticOptionsManager& Options, CAnyWindow &Wnd, 
+  UINT Optd, COLORREF &Var, COLORREF Default)
 {
     c_base::byte_t bt[4];
     bool invalid = false;

--- a/NppExec/src/DlgAdvancedOptions.h
+++ b/NppExec/src/DlgAdvancedOptions.h
@@ -66,10 +66,10 @@ class CAdvOptDlg : public CAnyWindow
         CAnyCheckBox m_chUseEditorColorsInConsole;
         CAnyCheckBox m_chUseEditorColorsInExecDlg;
 
-        CByteBuf     m_bufColorTextNorm;
-        CByteBuf     m_bufColorTextErr;
-        CByteBuf     m_bufColorTextMsg;
-        CByteBuf     m_bufColorBkgnd;
+        COLORREF     m_OrgColorTextNorm;
+        COLORREF     m_OrgColorTextErr;
+        COLORREF     m_OrgColorTextMsg;
+        COLORREF     m_OrgColorBkgnd;
         int          m_nREMaxLen;
         bool         m_bUseEditorColorsInConsole;
         bool         m_bNppRestartRequired;

--- a/NppExec/src/DlgConsoleOutputFilter.cpp
+++ b/NppExec/src/DlgConsoleOutputFilter.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DlgConsoleOutputFilter.h"
 #include "Resource.h"
 #include "NppExec.h"
+#include "PickColorBtn.h"
 
 
 // for Dev-C++
@@ -30,6 +31,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define  TCS_HOTTRACK  0x0040
 #endif
 
+enum {
+    HL_FIRSTCOLORID = IDC_HIGHLIGHT_COLOR1,
+    HL_LASTCOLORID = IDC_HIGHLIGHT_COLOR10,
+};
 
 CConsoleOutputFilterDlg      ConsoleOutputFilterDlg;
 
@@ -261,6 +266,7 @@ void CConsoleOutputFilterDlg::OnBtOK()
 
     if ( m_hTabDlg[DLG_HGLT] )
     {
+        HWND hDlgHglt = GetParent(m_ch_Recognition[0].m_hWnd);
         CWarningAnalyzer& WarningAnalyzer = Runtime::GetNppExec().GetWarningAnalyzer();
         CWarningAnalyzer::TEffect Effect;
 
@@ -271,17 +277,10 @@ void CConsoleOutputFilterDlg::OnBtOK()
             Effect.Bold       = m_ch_Recognition_Style[i][FILTER_REC_BOLD      ].IsChecked() ? true : false;
             Effect.Underlined = m_ch_Recognition_Style[i][FILTER_REC_UNDERLINED].IsChecked() ? true : false;
 
-            str[1] = 0;
-            m_ed_Recognition_Color[i][FILTER_REC_RED  ].GetWindowText( str, OUTPUTFILTER_BUFSIZE - 1 );
-            Effect.Red   = CWarningAnalyzer::xtou( str[0], str[1] );
-
-            str[1] = 0;
-            m_ed_Recognition_Color[i][FILTER_REC_GREEN].GetWindowText( str, OUTPUTFILTER_BUFSIZE - 1 );
-            Effect.Green = CWarningAnalyzer::xtou( str[0], str[1] );
-
-            str[1] = 0;
-            m_ed_Recognition_Color[i][FILTER_REC_BLUE ].GetWindowText( str, OUTPUTFILTER_BUFSIZE - 1 );
-            Effect.Blue  = CWarningAnalyzer::xtou( str[0], str[1] );
+            COLORREF color = PickColorBtn_GetColor(GetDlgItem(hDlgHglt, HL_FIRSTCOLORID + i));
+            Effect.Red = GetRValue(color);
+            Effect.Green = GetGValue(color);
+            Effect.Blue = GetBValue(color);
 
             m_cb_Recognition[i].GetWindowText(str, OUTPUTFILTER_BUFSIZE - 1);
             WarningAnalyzer.SetMask( i, str );
@@ -736,9 +735,6 @@ void CConsoleOutputFilterDlg::OnInitDlgHglt(HWND hDlgHglt)
     {
         m_ch_Recognition[i].m_hWnd          = ::GetDlgItem(hDlgHglt, IDC_CH_HIGHLIGHT1 + i);
         m_cb_Recognition[i].m_hWnd          = ::GetDlgItem(hDlgHglt, IDC_CB_HIGHLIGHT1 + i);
-        m_ed_Recognition_Color[i][0].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_ED_HIGHLIGHT_R1 + i);
-        m_ed_Recognition_Color[i][1].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_ED_HIGHLIGHT_G1 + i);
-        m_ed_Recognition_Color[i][2].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_ED_HIGHLIGHT_B1 + i);
         m_ch_Recognition_Style[i][0].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_CH_HIGHLIGHT_I1 + i);
         m_ch_Recognition_Style[i][1].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_CH_HIGHLIGHT_B1 + i);
         m_ch_Recognition_Style[i][2].m_hWnd = ::GetDlgItem(hDlgHglt, IDC_CH_HIGHLIGHT_U1 + i);
@@ -757,20 +753,20 @@ void CConsoleOutputFilterDlg::OnInitDlgHglt(HWND hDlgHglt)
         if ( RecMask[0] )
         {
             CWarningAnalyzer::TEffect Effect;
-            TCHAR col[4];
 
             WarningAnalyzer.GetEffect( i, Effect );
             m_ch_Recognition[i].SetCheck( Effect.Enable );
             m_ch_Recognition_Style[i][FILTER_REC_ITALIC    ].SetCheck( Effect.Italic     );
             m_ch_Recognition_Style[i][FILTER_REC_BOLD      ].SetCheck( Effect.Bold       );
             m_ch_Recognition_Style[i][FILTER_REC_UNDERLINED].SetCheck( Effect.Underlined );
-            m_ed_Recognition_Color[i][FILTER_REC_RED  ].SetWindowText( CWarningAnalyzer::utox( Effect.Red,   col, 3 ) );
-            m_ed_Recognition_Color[i][FILTER_REC_GREEN].SetWindowText( CWarningAnalyzer::utox( Effect.Green, col, 3 ) );
-            m_ed_Recognition_Color[i][FILTER_REC_BLUE ].SetWindowText( CWarningAnalyzer::utox( Effect.Blue,  col, 3 ) );
+
+            COLORREF color = RGB(Effect.Red, Effect.Green, Effect.Blue);
+            PickColorBtn_SetColor(GetDlgItem(hDlgHglt, HL_FIRSTCOLORID + i), color);
         }
     }
 
     updateComboBoxContent(m_cb_Recognition, -1, RECOGNITION_ITEMS, m_HighlightHistory);
+    PickColorBtn_InitializeTooltips(hDlgHglt, HL_FIRSTCOLORID, HL_LASTCOLORID);
 }
 
 void CConsoleOutputFilterDlg::OnInitDlgRplc(HWND hDlgRplc)
@@ -919,12 +915,17 @@ INT_PTR CALLBACK ConsoleHighLightFilterProc(HWND hDlg, UINT uMsg, WPARAM wParam,
             {
                 ConsoleOutputFilterDlg.OnCbnDropDown(LOWORD(wParam));
             }
-            return 0;
+            break;
 
         case WM_CTLCOLORSTATIC:
             return ConsoleOutputFilterDlg.OnCtlColorStatic(hDlg, wParam, lParam);
 
-        default:
-            return 0;
+        case WM_NOTIFY:
+            PickColorBtn_HandleTooltipsNotify(hDlg, wParam, lParam);
+            break;
     }
+
+    // Note: This is greedy and must be the last handler
+    if (PickColorBtn::HandleMessageForDialog(hDlg, uMsg, wParam, lParam)) return true;
+    return false;
 }

--- a/NppExec/src/DlgConsoleOutputFilter.cpp
+++ b/NppExec/src/DlgConsoleOutputFilter.cpp
@@ -926,6 +926,6 @@ INT_PTR CALLBACK ConsoleHighLightFilterProc(HWND hDlg, UINT uMsg, WPARAM wParam,
     }
 
     // Note: This is greedy and must be the last handler
-    if (PickColorBtn::HandleMessageForDialog(hDlg, uMsg, wParam, lParam)) return true;
+    if (PickColorBtn_HandleMessageForDialog(hDlg, uMsg, wParam, lParam)) return true;
     return false;
 }

--- a/NppExec/src/DlgConsoleOutputFilter.h
+++ b/NppExec/src/DlgConsoleOutputFilter.h
@@ -38,10 +38,6 @@ public:
   static const int HISTORY_ITEMS         = 16;
   static const int REPLACE_ITEMS         = 4;
 
-  static const int FILTER_REC_RED        = 0;
-  static const int FILTER_REC_GREEN      = 1;
-  static const int FILTER_REC_BLUE       = 2;
-  static const int FILTER_REC_COLOR      = 3;
   static const int FILTER_REC_ITALIC     = 0;
   static const int FILTER_REC_BOLD       = 1;
   static const int FILTER_REC_UNDERLINED = 2;
@@ -81,7 +77,6 @@ private:
 
   CAnyCheckBox m_ch_Recognition[RECOGNITION_ITEMS];
   CAnyComboBox m_cb_Recognition[RECOGNITION_ITEMS];
-  CAnyWindow   m_ed_Recognition_Color[RECOGNITION_ITEMS][FILTER_REC_COLOR];
   CAnyCheckBox m_ch_Recognition_Style[RECOGNITION_ITEMS][FILTER_REC_STYLE];
 
 public:

--- a/NppExec/src/NppExec.rc
+++ b/NppExec/src/NppExec.rc
@@ -295,129 +295,76 @@ IDD_CONSOLE_HIGHLIGHTFILTER DIALOGEX
 BEGIN
 
     GROUPBOX        "HighLight mask(s):", IDC_ST_FILTER_HIGHLIGHT,     5,   5, 369,  178
-    GROUPBOX        "Red",                IDC_RED,                   206,  10,  29,  169
-    GROUPBOX        "Green",              IDC_GREEN,                 240,  10,  29,  169
-    GROUPBOX        "Blue",               IDC_BLUE,                  274,  10,  29,  169
     GROUPBOX        "I",                  IDC_ITALIC,                308,  10,  17,  169
     GROUPBOX        "B",                  IDC_BOLD,                  330,  10,  17,  169
     GROUPBOX        "U",                  IDC_UNDERLINED,            352,  10,  17,  169
 
     CONTROL         "",IDC_CH_HIGHLIGHT1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10,  20,   9,   9
-    COMBOBOX           IDC_CB_HIGHLIGHT1,                             22,  18, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209,  21,   7,  10
-    EDITTEXT           IDC_ED_HIGHLIGHT_R1,                          217,  19,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243,  21,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G1,                             251,  19,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277,  21,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B1,                             285,  19,  13,  12
+    COMBOBOX           IDC_CB_HIGHLIGHT1,                             22,  18, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR1,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 18, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312,  20,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334,  20,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356,  20,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10,  36,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT2,                                22,  34, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209,  37,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R2,                             217,  35,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243,  37,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G2,                             251,  35,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277,  37,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B2,                             285,  35,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT2,                                22,  34, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR2,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 34, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312,  36,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334,  36,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356,  36,   9,   9
     
     CONTROL         "",IDC_CH_HIGHLIGHT3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10,  52,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT3,                                22,  50, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209,  53,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R3,                             217,  51,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243,  53,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G3,                             251,  51,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277,  53,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B3,                             285,  51,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT3,                                22,  50, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR3,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 50, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312,  52,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334,  52,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356,  52,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT4,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10,  68,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT4,                                22,  66, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209,  69,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R4,                             217,  67,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243,  69,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G4,                             251,  67,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277,  69,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B4,                             285,  67,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT4,                                22,  66, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR4,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 66, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I4,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312,  68,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B4,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334,  68,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U4,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356,  68,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT5,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10,  84,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT5,                                22,  82, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209,  85,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R5,                             217,  83,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243,  85,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G5,                             251,  83,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277,  85,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B5,                             285,  83,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT5,                                22,  82, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR5,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 82, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I5,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312,  84,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B5,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334,  84,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U5,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356,  84,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10, 100,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT6,                                22,  98, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209, 101,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R6,                             217,  99,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243, 101,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G6,                             251,  99,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277, 101,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B6,                             285,  99,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT6,                                22,  98, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR6,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 98, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312, 100,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334, 100,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356, 100,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT7,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10, 116,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT7,                                22, 114, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209, 117,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R7,                             217, 115,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243, 117,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G7,                             251, 115,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277, 117,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B7,                             285, 115,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT7,                                22, 114, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR7,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 114, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I7,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312, 116,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B7,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334, 116,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U7,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356, 116,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10, 132,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT8,                                22, 130, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209, 133,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R8,                             217, 131,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243, 133,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G8,                             251, 131,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277, 133,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B8,                             285, 131,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT8,                                22, 130, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR8,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 130, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312, 132,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334, 132,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U8,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356, 132,   9,   9
     
     CONTROL         "",IDC_CH_HIGHLIGHT9,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10, 148,   9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT9,                                22, 146, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                209, 149,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R9,                             217, 147,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                243, 149,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G9,                             251, 147,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                277, 149,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B9,                             285, 147,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT9,                                22, 146, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR9,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 146, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I9,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312, 148,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B9,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334, 148,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U9,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356, 148,   9,   9
 
     CONTROL         "",IDC_CH_HIGHLIGHT10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,    10, 164,  9,   9
-    COMBOBOX        IDC_CB_HIGHLIGHT10,                                22, 162, 179,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "0x", IDC_STATIC,                                 209, 165,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_R10,                             217, 163,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                 243, 165,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_G10,                             251, 163,  13,  12
-    LTEXT           "0x", IDC_STATIC,                                 277, 165,   7,  10
-    EDITTEXT        IDC_ED_HIGHLIGHT_B10,                             285, 163,  13,  12
+    COMBOBOX        IDC_CB_HIGHLIGHT10,                                22, 162, 266,  100, CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_HIGHLIGHT_COLOR10,"Button",BS_OWNERDRAW | WS_TABSTOP,    291, 162, 13, 13, WS_EX_STATICEDGE
     CONTROL         "",IDC_CH_HIGHLIGHT_I10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 312, 164,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_B10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 334, 164,   9,   9
     CONTROL         "",IDC_CH_HIGHLIGHT_U10,"Button",BS_AUTOCHECKBOX | WS_TABSTOP, 356, 164,   9,   9
@@ -468,14 +415,14 @@ BEGIN
     COMBOBOX        IDC_CB_OPT_SAVECMDHST, 292, 168, 48, 57, WS_TABSTOP | WS_VSCROLL | CBS_DROPDOWNLIST | CBS_HASSTRINGS
     LTEXT           "CommentDelimiter", IDC_ST_OPT_COMMENTDELIM, 174, 186, 112, 8
     EDITTEXT        IDC_ED_OPT_COMMENTDELIM, 292, 184, 48, 14, ES_AUTOHSCROLL
-    LTEXT           "TextColorNormal (RR GG BB)", IDC_ST_OPT_TEXTCOLORNORM, 174, 202, 112, 8
-    EDITTEXT        IDC_ED_OPT_TEXTCOLORNORM, 292, 200, 48, 14, ES_AUTOHSCROLL
-    LTEXT           "TextColorError (RR GG BB)", IDC_ST_OPT_TEXTCOLORERR, 174, 218, 112, 8
-    EDITTEXT        IDC_ED_OPT_TEXTCOLORERR, 292, 216, 48, 14, ES_AUTOHSCROLL
-    LTEXT           "TextColorMessage (RR GG BB)", IDC_ST_OPT_TEXTCOLORMSG, 174, 234, 112, 8
-    EDITTEXT        IDC_ED_OPT_TEXTCOLORMSG, 292, 232, 48, 14, ES_AUTOHSCROLL
-    LTEXT           "BackgroundColor (RR GG BB)", IDC_ST_OPT_BKCOLOR, 174, 250, 112, 8
-    EDITTEXT        IDC_ED_OPT_BKCOLOR, 292, 248, 48, 14, ES_AUTOHSCROLL
+    LTEXT           "TextColorNormal", IDC_ST_OPT_TEXTCOLORNORM, 174, 202, 112, 8
+    CONTROL         "",IDC_ED_OPT_TEXTCOLORNORM, "Button", BS_OWNERDRAW | WS_TABSTOP, 292, 200, 48, 14, WS_EX_STATICEDGE
+    LTEXT           "TextColorError", IDC_ST_OPT_TEXTCOLORERR, 174, 218, 112, 8
+    CONTROL         "",IDC_ED_OPT_TEXTCOLORERR, "Button", BS_OWNERDRAW | WS_TABSTOP, 292, 216, 48, 14, WS_EX_STATICEDGE
+    LTEXT           "TextColorMessage", IDC_ST_OPT_TEXTCOLORMSG, 174, 234, 112, 8
+    CONTROL         "",IDC_ED_OPT_TEXTCOLORMSG, "Button", BS_OWNERDRAW | WS_TABSTOP, 292, 232, 48, 14, WS_EX_STATICEDGE
+    LTEXT           "BackgroundColor", IDC_ST_OPT_BKCOLOR, 174, 250, 112, 8
+    CONTROL         "",IDC_ED_OPT_BKCOLOR, "Button", BS_OWNERDRAW | WS_TABSTOP, 292, 248, 48, 14, WS_EX_STATICEDGE
     CONTROL         "Use Editor colors in the Console", IDC_CH_OPT_USEEDITORCOLORS_CONSOLE, "Button", BS_AUTOCHECKBOX | 
                     WS_CHILD | WS_TABSTOP, 174, 268, 155, 10
     CONTROL         "Use Editor colors in the ""Execute"" dialog", IDC_CH_OPT_USEEDITORCOLORS_EXECDLG, "Button", BS_AUTOCHECKBOX | 

--- a/NppExec/src/PickColorBtn.cpp
+++ b/NppExec/src/PickColorBtn.cpp
@@ -1,0 +1,132 @@
+/*
+This file is part of NppExec
+Copyright (C) 2023 Anders Kjersem.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <windows.h>
+#include <commdlg.h>
+#include <CommCtrl.h>
+#include "PickColorBtn.h"
+
+
+static inline void PickColorBtn_FillRectColor(HDC hDC, const RECT*pR, COLORREF Clr)
+{
+    UINT orgbc = SetBkColor(hDC, Clr);
+    ExtTextOut(hDC, 0, 0, ETO_OPAQUE, pR, NULL, 0, NULL);
+    SetBkColor(hDC, orgbc);
+}
+
+INT_PTR CALLBACK PickColorBtn_HandleMessage(HWND hDlg, UINT Msg, WPARAM WPar, LPARAM LPar, LRESULT *RetVal)
+{
+    DRAWITEMSTRUCT*pDIS = (DRAWITEMSTRUCT*) LPar;
+    switch(Msg)
+    {
+    case WM_DRAWITEM:
+        if (pDIS->CtlType != ODT_BUTTON)
+        {
+            break;
+        }
+
+        if (pDIS->itemAction != ODA_FOCUS)
+        {
+            if (pDIS->itemState & ODS_DISABLED)
+            {
+                HBRUSH hBr = CreateHatchBrush(HS_DIAGCROSS, GetSysColor(COLOR_GRAYTEXT));
+                UINT obc = SetBkColor(pDIS->hDC, GetSysColor(COLOR_3DFACE));
+                FillRect(pDIS->hDC, &pDIS->rcItem, hBr);
+                SetBkColor(pDIS->hDC, obc);
+                DeleteObject(hBr);
+            }
+            else
+            {
+                PickColorBtn_FillRectColor(pDIS->hDC, &pDIS->rcItem, PickColorBtn_GetColor(pDIS->hwndItem) & 0xffffff);
+            }
+        }
+
+        if (pDIS->itemAction == ODA_FOCUS || (pDIS->itemState & ODS_FOCUS))
+        {
+            DrawFocusRect(pDIS->hDC, &pDIS->rcItem);
+        }
+        return (*RetVal = (SIZE_T) pDIS);
+
+    case WM_COMMAND:
+        if (LPar && (GetWindowLongPtr((HWND) LPar, GWL_STYLE) & BS_TYPEMASK) == BS_OWNERDRAW)
+        {
+            SIZE_T id = GetWindowLongPtr((HWND) LPar, GWLP_ID);
+            if (MAKEWPARAM(id, BN_CLICKED) == WPar)
+            {
+                HWND hCtl = (HWND) LPar;
+                COLORREF orgclr = PickColorBtn_GetColor(hCtl) & 0xffffff;
+                COLORREF colors[16];
+                for (SIZE_T i = 0; i < 16; ++i) colors[i] = RGB(i * 16, i * 16, i * 16);
+
+                CHOOSECOLOR cc;
+                cc.lStructSize = sizeof(cc);
+                cc.hwndOwner = hCtl;
+                cc.Flags = CC_RGBINIT | CC_ANYCOLOR | CC_FULLOPEN;
+                cc.rgbResult = colors[0] = orgclr;
+                cc.lpCustColors = colors;
+
+                SendMessage(hDlg, WM_COMMAND, MAKEWPARAM(id, PCBN_INITCHOOSE), (SIZE_T) &cc); // Set cc.lpCustColors to something better if you wish
+                if (ChooseColor(&cc))
+                {
+                    PickColorBtn_SetColor((HWND) LPar, cc.rgbResult);
+                }
+                return TRUE;
+            }
+        }
+        break;
+    }
+    return FALSE;
+}
+
+INT_PTR CALLBACK PickColorBtn_HandleMessageForDialog(HWND hDlg, UINT Msg, WPARAM WPar, LPARAM LPar)
+{
+    LRESULT r;
+    LRESULT handled = PickColorBtn_HandleMessage(hDlg, Msg, WPar, LPar, &r);
+    if (handled) SetWindowLongPtr(hDlg, DWLP_MSGRESULT, r);
+    return handled;
+}
+
+
+void PickColorBtn_InitializeTooltips(HWND hDlg, UINT first, UINT last)
+{
+    HWND hTT = CreateWindowEx(WS_EX_TOPMOST|WS_EX_TOOLWINDOW, TOOLTIPS_CLASS, 0, WS_POPUP|TTS_ALWAYSTIP|TTS_NOPREFIX, 0, 0, 0, 0, hDlg, 0, 0, 0);
+    TOOLINFO ti;
+    ti.cbSize = sizeof(ti);
+    ti.hwnd = hDlg;
+    ti.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+    ti.lpszText = LPSTR_TEXTCALLBACK;
+
+    for ( UINT id = first; id <= last; ++id )
+    {
+        HWND hCtl = ::GetDlgItem(hDlg, id);
+        TCHAR buf[42];
+        if (GetClassName(hCtl, buf, 42) && (buf[0]|32) != 'b') continue; // Only buttons
+        ti.uId = (SIZE_T) hCtl;
+        if ( hTT && ti.uId ) SendMessage(hTT, TTM_ADDTOOL, 0, (LPARAM) &ti);
+    }
+}
+
+void PickColorBtn_HandleTooltipsNotify(HWND hDlg, WPARAM, LPARAM lParam)
+{
+    NMTTDISPINFO*pTTDI = (NMTTDISPINFO*) lParam;
+    if ( pTTDI->hdr.code == TTN_GETDISPINFO && (pTTDI->uFlags & TTF_IDISHWND) )
+    {
+        COLORREF c = PickColorBtn_GetColor((HWND) pTTDI->hdr.idFrom);
+        wsprintf(pTTDI->szText, TEXT("#%.2X%.2X%.2X"), GetRValue(c), GetGValue(c), GetBValue(c));
+    }
+}

--- a/NppExec/src/PickColorBtn.h
+++ b/NppExec/src/PickColorBtn.h
@@ -19,9 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef PICKCOLORBTN_INC
 #define PICKCOLORBTN_INC
 #include <windows.h>
-#include <commdlg.h>
-#include <CommCtrl.h>
-
 
 enum PICKCOLORBTNNOTIFYCMD {
     PCBN_INITCHOOSE = 0x8000+0,
@@ -30,116 +27,10 @@ enum PICKCOLORBTNNOTIFYCMD {
 #define PickColorBtn_GetColor(h) ( (COLORREF) GetWindowLongPtr((h), GWLP_USERDATA) )
 #define PickColorBtn_SetColor(h, c) ( SetWindowLongPtr((h), GWLP_USERDATA, (c)), InvalidateRect((h), NULL, false) )
 
-#ifndef PickColorBtn_FillRectColor
-static inline void PickColorBtn_FillRectColor(HDC hDC, const RECT*pR, COLORREF Clr)
-{
-    UINT orgbc = SetBkColor(hDC, Clr);
-    ExtTextOut(hDC, 0, 0, ETO_OPAQUE, pR, NULL, 0, NULL);
-    SetBkColor(hDC, orgbc);
-}
-#endif
+INT_PTR CALLBACK PickColorBtn_HandleMessage(HWND hDlg, UINT Msg, WPARAM WPar, LPARAM LPar, LRESULT *RetVal);
+INT_PTR CALLBACK PickColorBtn_HandleMessageForDialog(HWND hDlg, UINT Msg, WPARAM WPar, LPARAM LPar);
 
-struct PickColorBtn {
-    template<class T> static INT_PTR CALLBACK HandleMessage(T hDlg, UINT Msg, WPARAM WPar, LPARAM LPar, LRESULT *RetVal)
-    {
-        DRAWITEMSTRUCT*pDIS = (DRAWITEMSTRUCT*) LPar;
-        switch(Msg)
-        {
-        case WM_DRAWITEM:
-            if (pDIS->CtlType != ODT_BUTTON)
-            {
-                break;
-            }
-
-            if (pDIS->itemAction != ODA_FOCUS)
-            {
-                if (pDIS->itemState & ODS_DISABLED)
-                {
-                    HBRUSH hBr = CreateHatchBrush(HS_DIAGCROSS, GetSysColor(COLOR_GRAYTEXT));
-                    UINT obc = SetBkColor(pDIS->hDC, GetSysColor(COLOR_3DFACE));
-                    FillRect(pDIS->hDC, &pDIS->rcItem, hBr);
-                    SetBkColor(pDIS->hDC, obc);
-                    DeleteObject(hBr);
-                }
-                else
-                {
-                    PickColorBtn_FillRectColor(pDIS->hDC, &pDIS->rcItem, PickColorBtn_GetColor(pDIS->hwndItem) & 0xffffff);
-                }
-            }
-
-            if (pDIS->itemAction == ODA_FOCUS || (pDIS->itemState & ODS_FOCUS))
-            {
-                DrawFocusRect(pDIS->hDC, &pDIS->rcItem);
-            }
-            return (*RetVal = (SIZE_T) pDIS);
-
-        case WM_COMMAND:
-            if (LPar && (GetWindowLongPtr((HWND) LPar, GWL_STYLE) & BS_TYPEMASK) == BS_OWNERDRAW)
-            {
-                SIZE_T id = GetWindowLongPtr((HWND) LPar, GWLP_ID);
-                if (MAKEWPARAM(id, BN_CLICKED) == WPar)
-                {
-                    HWND hCtl = (HWND) LPar;
-                    COLORREF orgclr = PickColorBtn_GetColor(hCtl) & 0xffffff;
-                    COLORREF colors[16];
-                    for (SIZE_T i = 0; i < 16; ++i) colors[i] = RGB(i * 16, i * 16, i * 16);
-
-                    CHOOSECOLOR cc;
-                    cc.lStructSize = sizeof(cc);
-                    cc.hwndOwner = hCtl;
-                    cc.Flags = CC_RGBINIT | CC_ANYCOLOR | CC_FULLOPEN;
-                    cc.rgbResult = colors[0] = orgclr;
-                    cc.lpCustColors = colors;
-
-                    SendMessage(hDlg, WM_COMMAND, MAKEWPARAM(id, PCBN_INITCHOOSE), (SIZE_T) &cc); // Set cc.lpCustColors to something better if you wish
-                    if (ChooseColor(&cc))
-                    {
-                        PickColorBtn_SetColor((HWND) LPar, cc.rgbResult);
-                    }
-                    return TRUE;
-                }
-            }
-            break;
-        }
-        return FALSE;
-    }
-
-    template<class T> static INT_PTR CALLBACK HandleMessageForDialog(T hDlg, UINT Msg, WPARAM WPar, LPARAM LPar)
-    {
-        LRESULT r;
-        LRESULT handled = HandleMessage(hDlg, Msg, WPar, LPar, &r);
-        if (handled) SetWindowLongPtr(hDlg, DWLP_MSGRESULT, r);
-        return handled;
-    }
-};
-
-template<class T> static void PickColorBtn_InitializeTooltips(T hDlg, UINT first, UINT last)
-{
-    HWND hTT = CreateWindowEx(WS_EX_TOPMOST|WS_EX_TOOLWINDOW, TOOLTIPS_CLASS, 0, WS_POPUP|TTS_ALWAYSTIP|TTS_NOPREFIX, 0, 0, 0, 0, hDlg, 0, 0, 0);
-    TOOLINFO ti;
-    ti.cbSize = sizeof(ti);
-    ti.hwnd = hDlg;
-    ti.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
-    ti.lpszText = LPSTR_TEXTCALLBACK;
-
-    for ( UINT id = first; id <= last; ++id )
-    {
-        HWND hCtl = ::GetDlgItem(hDlg, id);
-        TCHAR buf[42];
-        if (GetClassName(hCtl, buf, 42) && (buf[0]|32) != 'b') continue; // Only buttons
-        ti.uId = (SIZE_T) hCtl;
-        if ( hTT && ti.uId ) SendMessage(hTT, TTM_ADDTOOL, 0, (LPARAM) &ti);
-    }
-}
-
-template<class T> static void PickColorBtn_HandleTooltipsNotify(T hDlg, WPARAM, LPARAM lParam)
-{
-    NMTTDISPINFO*pTTDI = (NMTTDISPINFO*) lParam;
-    if ( pTTDI->hdr.code == TTN_GETDISPINFO && (pTTDI->uFlags & TTF_IDISHWND) )
-    {
-        COLORREF c = PickColorBtn_GetColor((HWND) pTTDI->hdr.idFrom);
-        wsprintf(pTTDI->szText, TEXT("#%.2X%.2X%.2X"), GetRValue(c), GetGValue(c), GetBValue(c));
-    }
-}
+void PickColorBtn_InitializeTooltips(HWND hDlg, UINT first, UINT last);
+void PickColorBtn_HandleTooltipsNotify(HWND hDlg, WPARAM, LPARAM lParam);
 
 #endif

--- a/NppExec/src/PickColorBtn.h
+++ b/NppExec/src/PickColorBtn.h
@@ -1,0 +1,144 @@
+/*
+This file is part of NppExec
+Copyright (C) 2023 Anders Kjersem.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PICKCOLORBTN_INC
+#define PICKCOLORBTN_INC
+#include <windows.h>
+#include <commdlg.h>
+
+
+enum PICKCOLORBTNNOTIFYCMD {
+    PCBN_INITCHOOSE = 0x8000+0,
+};
+
+#define PickColorBtn_GetColor(h) ( (COLORREF) GetWindowLongPtr((h), GWLP_USERDATA) )
+#define PickColorBtn_SetColor(h, c) ( SetWindowLongPtr((h), GWLP_USERDATA, (c)), InvalidateRect((h), NULL, false) )
+
+#ifndef PickColorBtn_FillRectColor
+static inline void PickColorBtn_FillRectColor(HDC hDC, const RECT*pR, COLORREF Clr)
+{
+    UINT orgbc = SetBkColor(hDC, Clr);
+    ExtTextOut(hDC, 0, 0, ETO_OPAQUE, pR, NULL, 0, NULL);
+    SetBkColor(hDC, orgbc);
+}
+#endif
+
+struct PickColorBtn {
+    template<class T> static INT_PTR CALLBACK HandleMessage(T hDlg, UINT Msg, WPARAM WPar, LPARAM LPar, LRESULT *RetVal)
+    {
+        DRAWITEMSTRUCT*pDIS = (DRAWITEMSTRUCT*) LPar;
+        switch(Msg)
+        {
+        case WM_DRAWITEM:
+            if (pDIS->CtlType != ODT_BUTTON)
+            {
+                break;
+            }
+
+            if (pDIS->itemAction != ODA_FOCUS)
+            {
+                if (pDIS->itemState & ODS_DISABLED)
+                {
+                    HBRUSH hBr = CreateHatchBrush(HS_DIAGCROSS, GetSysColor(COLOR_GRAYTEXT));
+                    UINT obc = SetBkColor(pDIS->hDC, GetSysColor(COLOR_3DFACE));
+                    FillRect(pDIS->hDC, &pDIS->rcItem, hBr);
+                    SetBkColor(pDIS->hDC, obc);
+                    DeleteObject(hBr);
+                }
+                else
+                {
+                    PickColorBtn_FillRectColor(pDIS->hDC, &pDIS->rcItem, PickColorBtn_GetColor(pDIS->hwndItem) & 0xffffff);
+                }
+            }
+
+            if (pDIS->itemAction == ODA_FOCUS || (pDIS->itemState & ODS_FOCUS))
+            {
+                DrawFocusRect(pDIS->hDC, &pDIS->rcItem);
+            }
+            return (*RetVal = (SIZE_T) pDIS);
+
+        case WM_COMMAND:
+            if (LPar && (GetWindowLongPtr((HWND) LPar, GWL_STYLE) & BS_TYPEMASK) == BS_OWNERDRAW)
+            {
+                SIZE_T id = GetWindowLongPtr((HWND) LPar, GWLP_ID);
+                if (MAKEWPARAM(id, BN_CLICKED) == WPar)
+                {
+                    HWND hCtl = (HWND) LPar;
+                    COLORREF orgclr = PickColorBtn_GetColor(hCtl) & 0xffffff;
+                    COLORREF colors[16];
+                    for (SIZE_T i = 0; i < 16; ++i) colors[i] = RGB(i * 16, i * 16, i * 16);
+
+                    CHOOSECOLOR cc;
+                    cc.lStructSize = sizeof(cc);
+                    cc.hwndOwner = hCtl;
+                    cc.Flags = CC_RGBINIT | CC_ANYCOLOR | CC_FULLOPEN;
+                    cc.rgbResult = colors[0] = orgclr;
+                    cc.lpCustColors = colors;
+
+                    SendMessage(hDlg, WM_COMMAND, MAKEWPARAM(id, PCBN_INITCHOOSE), (SIZE_T) &cc); // Set cc.lpCustColors to something better if you wish
+                    if (ChooseColor(&cc))
+                    {
+                        PickColorBtn_SetColor((HWND) LPar, cc.rgbResult);
+                    }
+                    return TRUE;
+                }
+            }
+            break;
+        }
+        return FALSE;
+    }
+
+    template<class T> static INT_PTR CALLBACK HandleMessageForDialog(T hDlg, UINT Msg, WPARAM WPar, LPARAM LPar)
+    {
+        LRESULT r;
+        LRESULT handled = HandleMessage(hDlg, Msg, WPar, LPar, &r);
+        if (handled) SetWindowLongPtr(hDlg, DWLP_MSGRESULT, r);
+        return handled;
+    }
+};
+
+template<class T> static void PickColorBtn_InitializeTooltips(T hDlg, UINT first, UINT last)
+{
+    HWND hTT = CreateWindowEx(WS_EX_TOPMOST|WS_EX_TOOLWINDOW, TOOLTIPS_CLASS, 0, WS_POPUP|TTS_ALWAYSTIP|TTS_NOPREFIX, 0, 0, 0, 0, hDlg, 0, 0, 0);
+    TOOLINFO ti;
+    ti.cbSize = sizeof(ti);
+    ti.hwnd = hDlg;
+    ti.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+    ti.lpszText = LPSTR_TEXTCALLBACK;
+
+    for ( UINT id = first; id <= last; ++id )
+    {
+        HWND hCtl = ::GetDlgItem(hDlg, id);
+        TCHAR buf[42];
+        if (GetClassName(hCtl, buf, 42) && (buf[0]|32) != 'b') continue; // Only buttons
+        ti.uId = (SIZE_T) hCtl;
+        if ( hTT && ti.uId ) SendMessage(hTT, TTM_ADDTOOL, 0, (LPARAM) &ti);
+    }
+}
+
+template<class T> static void PickColorBtn_HandleTooltipsNotify(T hDlg, WPARAM, LPARAM lParam)
+{
+    NMTTDISPINFO*pTTDI = (NMTTDISPINFO*) lParam;
+    if ( pTTDI->hdr.code == TTN_GETDISPINFO && (pTTDI->uFlags & TTF_IDISHWND) )
+    {
+        COLORREF c = PickColorBtn_GetColor((HWND) pTTDI->hdr.idFrom);
+        wsprintf(pTTDI->szText, TEXT("#%.2X%.2X%.2X"), GetRValue(c), GetGValue(c), GetBValue(c));
+    }
+}
+
+#endif

--- a/NppExec/src/PickColorBtn.h
+++ b/NppExec/src/PickColorBtn.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PICKCOLORBTN_INC
 #include <windows.h>
 #include <commdlg.h>
+#include <CommCtrl.h>
 
 
 enum PICKCOLORBTNNOTIFYCMD {

--- a/NppExec/src/resource.h
+++ b/NppExec/src/resource.h
@@ -88,38 +88,16 @@
 #define IDC_CB_HIGHLIGHT9                       1089
 #define IDC_CB_HIGHLIGHT10                      1090
 
-#define IDC_ED_HIGHLIGHT_R1                     1091
-#define IDC_ED_HIGHLIGHT_R2                     1092
-#define IDC_ED_HIGHLIGHT_R3                     1093
-#define IDC_ED_HIGHLIGHT_R4                     1094
-#define IDC_ED_HIGHLIGHT_R5                     1095
-#define IDC_ED_HIGHLIGHT_R6                     1096
-#define IDC_ED_HIGHLIGHT_R7                     1097
-#define IDC_ED_HIGHLIGHT_R8                     1098
-#define IDC_ED_HIGHLIGHT_R9                     1099
-#define IDC_ED_HIGHLIGHT_R10                    1100
-
-#define IDC_ED_HIGHLIGHT_G1                     1101
-#define IDC_ED_HIGHLIGHT_G2                     1102
-#define IDC_ED_HIGHLIGHT_G3                     1103
-#define IDC_ED_HIGHLIGHT_G4                     1104
-#define IDC_ED_HIGHLIGHT_G5                     1105
-#define IDC_ED_HIGHLIGHT_G6                     1106
-#define IDC_ED_HIGHLIGHT_G7                     1107
-#define IDC_ED_HIGHLIGHT_G8                     1108
-#define IDC_ED_HIGHLIGHT_G9                     1109
-#define IDC_ED_HIGHLIGHT_G10                    1110
-
-#define IDC_ED_HIGHLIGHT_B1                     1111
-#define IDC_ED_HIGHLIGHT_B2                     1112
-#define IDC_ED_HIGHLIGHT_B3                     1113
-#define IDC_ED_HIGHLIGHT_B4                     1114
-#define IDC_ED_HIGHLIGHT_B5                     1115
-#define IDC_ED_HIGHLIGHT_B6                     1116
-#define IDC_ED_HIGHLIGHT_B7                     1117
-#define IDC_ED_HIGHLIGHT_B8                     1118
-#define IDC_ED_HIGHLIGHT_B9                     1119
-#define IDC_ED_HIGHLIGHT_B10                    1120
+#define IDC_HIGHLIGHT_COLOR1                    1091
+#define IDC_HIGHLIGHT_COLOR2                    1092
+#define IDC_HIGHLIGHT_COLOR3                    1093
+#define IDC_HIGHLIGHT_COLOR4                    1094
+#define IDC_HIGHLIGHT_COLOR5                    1095
+#define IDC_HIGHLIGHT_COLOR6                    1096
+#define IDC_HIGHLIGHT_COLOR7                    1097
+#define IDC_HIGHLIGHT_COLOR8                    1098
+#define IDC_HIGHLIGHT_COLOR9                    1099
+#define IDC_HIGHLIGHT_COLOR10                   1100
 
 #define IDC_CH_HIGHLIGHT_U1                     1121
 #define IDC_CH_HIGHLIGHT_U2                     1122


### PR DESCRIPTION
Added custom color buttons that use the standard color picker when clicked.

![!Color buttons](https://github.com/d0vgan/nppexec/assets/151447/1c57e897-9437-498f-9cd9-d1f23c0b6826)

I assume that at some point you want to provide different colors for dark mode text/background in the advanced dialog but this PR is just a one for one replacement of the existing edit boxes.